### PR TITLE
Added tests for p3_atm and the Clone trait

### DIFF
--- a/src/c1_state_machine/p2_laundry_machine.rs
+++ b/src/c1_state_machine/p2_laundry_machine.rs
@@ -40,7 +40,7 @@ impl StateMachine for ClothesMachine {
     type Transition = ClothesAction;
 
     fn next_state(starting_state: &ClothesState, t: &ClothesAction) -> ClothesState {
-        todo!("Implement this state machine.")
+        todo!("Exercise 3")
     }
 }
 

--- a/src/c1_state_machine/p3_atm.rs
+++ b/src/c1_state_machine/p3_atm.rs
@@ -3,8 +3,6 @@
 //! entered the wrong pin.
 
 use super::StateMachine;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 
 /// The keys on the ATM keypad
 #[derive(Hash, Debug, PartialEq, Eq, Clone)]
@@ -164,9 +162,7 @@ fn sm_3_enter_single_digit_of_pin() {
 fn sm_3_enter_wrong_pin() {
     // Create hash of pin
     let pin = vec![Key::One, Key::Two, Key::Three, Key::Four];
-    let mut hasher = DefaultHasher::new();
-    pin.hash(&mut hasher);
-    let pin_hash = hasher.finish();
+    let pin_hash = crate::hash(&pin);
 
     let start = Atm {
         cash_inside: 10,
@@ -187,9 +183,7 @@ fn sm_3_enter_wrong_pin() {
 fn sm_3_enter_correct_pin() {
     // Create hash of pin
     let pin = vec![Key::One, Key::Two, Key::Three, Key::Four];
-    let mut hasher = DefaultHasher::new();
-    pin.hash(&mut hasher);
-    let pin_hash = hasher.finish();
+    let pin_hash = crate::hash(&pin);
 
     let start = Atm {
         cash_inside: 10,

--- a/src/c1_state_machine/p3_atm.rs
+++ b/src/c1_state_machine/p3_atm.rs
@@ -3,6 +3,8 @@
 //! entered the wrong pin.
 
 use super::StateMachine;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 /// The keys on the ATM keypad
 #[derive(Hash, Debug, PartialEq, Eq, Clone)]
@@ -94,6 +96,20 @@ fn sm_3_swipe_card_again_part_way_through() {
     };
 
     assert_eq!(end, expected);
+
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: vec![Key::One, Key::Three],
+    };
+    let end = Atm::next_state(&start, &Action::SwipeCard(1234));
+    let expected = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: vec![Key::One, Key::Three],
+    };
+
+    assert_eq!(end, expected);
 }
 
 #[test]
@@ -146,9 +162,15 @@ fn sm_3_enter_single_digit_of_pin() {
 
 #[test]
 fn sm_3_enter_wrong_pin() {
+    // Create hash of pin
+    let pin = vec![Key::One, Key::Two, Key::Three, Key::Four];
+    let mut hasher = DefaultHasher::new();
+    pin.hash(&mut hasher);
+    let pin_hash = hasher.finish();
+
     let start = Atm {
         cash_inside: 10,
-        expected_pin_hash: Auth::Authenticating(1234),
+        expected_pin_hash: Auth::Authenticating(pin_hash),
         keystroke_register: vec![Key::Three, Key::Three, Key::Three, Key::Three],
     };
     let end = Atm::next_state(&start, &Action::PressKey(Key::Enter));
@@ -163,9 +185,15 @@ fn sm_3_enter_wrong_pin() {
 
 #[test]
 fn sm_3_enter_correct_pin() {
+    // Create hash of pin
+    let pin = vec![Key::One, Key::Two, Key::Three, Key::Four];
+    let mut hasher = DefaultHasher::new();
+    pin.hash(&mut hasher);
+    let pin_hash = hasher.finish();
+
     let start = Atm {
         cash_inside: 10,
-        expected_pin_hash: Auth::Authenticating(1234),
+        expected_pin_hash: Auth::Authenticating(pin_hash),
         keystroke_register: vec![Key::One, Key::Two, Key::Three, Key::Four],
     };
     let end = Atm::next_state(&start, &Action::PressKey(Key::Enter));

--- a/src/c1_state_machine/p3_atm.rs
+++ b/src/c1_state_machine/p3_atm.rs
@@ -62,21 +62,6 @@ impl StateMachine for Atm {
     }
 }
 
-fn make_pin(keystroke: Vec<Key>) -> u64 {
-    keystroke
-        .iter()
-        .map(|x| match x {
-            Key::One => "1",
-            Key::Two => "2",
-            Key::Three => "3",
-            Key::Four => "4",
-            _ => panic!("dev fault"),
-        })
-        .collect::<String>()
-        .parse::<u64>()
-        .unwrap()
-}
-
 #[test]
 fn sm_3_simple_swipe_card() {
     let start = Atm {

--- a/src/c1_state_machine/p3_atm.rs
+++ b/src/c1_state_machine/p3_atm.rs
@@ -5,7 +5,7 @@
 use super::StateMachine;
 
 /// The keys on the ATM keypad
-#[derive(Hash, Debug, PartialEq, Eq)]
+#[derive(Hash, Debug, PartialEq, Eq, Clone)]
 pub enum Key {
     One,
     Two,
@@ -24,7 +24,7 @@ pub enum Action {
 }
 
 /// The various states of authentication possible with the ATM
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 enum Auth {
     /// No session has begun yet. Waiting for the user to swipe their card
     Waiting,
@@ -42,7 +42,7 @@ enum Auth {
 /// and the ATM automatically goes back to the main menu. If your pin is correct,
 /// the ATM waits for you to key in an amount of money to withdraw. Withdraws
 /// are bounded only by the cash in the machine (there is no account balance).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Atm {
     /// How much money is in the ATM
     cash_inside: u64,
@@ -53,14 +53,28 @@ pub struct Atm {
 }
 
 impl StateMachine for Atm {
-
     // Notice that we are using the same type for the state as we are using for the machine this time.
     type State = Self;
     type Transition = Action;
 
     fn next_state(starting_state: &Self::State, t: &Self::Transition) -> Self::State {
-        todo!()
+        todo!("Exercise 4")
     }
+}
+
+fn make_pin(keystroke: Vec<Key>) -> u64 {
+    keystroke
+        .iter()
+        .map(|x| match x {
+            Key::One => "1",
+            Key::Two => "2",
+            Key::Three => "3",
+            Key::Four => "4",
+            _ => panic!("dev fault"),
+        })
+        .collect::<String>()
+        .parse::<u64>()
+        .unwrap()
 }
 
 #[test]
@@ -82,40 +96,164 @@ fn sm_3_simple_swipe_card() {
 
 #[test]
 fn sm_3_swipe_card_again_part_way_through() {
-    todo!()
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: Vec::new(),
+    };
+    let end = Atm::next_state(&start, &Action::SwipeCard(1234));
+    let expected = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: Vec::new(),
+    };
+
+    assert_eq!(end, expected);
 }
 
 #[test]
 fn sm_3_press_key_before_card_swipe() {
-    todo!()
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Waiting,
+        keystroke_register: Vec::new(),
+    };
+    let end = Atm::next_state(&start, &Action::PressKey(Key::One));
+    let expected = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Waiting,
+        keystroke_register: Vec::new(),
+    };
+
+    assert_eq!(end, expected);
 }
 
 #[test]
 fn sm_3_enter_single_digit_of_pin() {
-    todo!()
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: Vec::new(),
+    };
+    let end = Atm::next_state(&start, &Action::PressKey(Key::One));
+    let expected = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: vec![Key::One],
+    };
+
+    assert_eq!(end, expected);
+
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: vec![Key::One],
+    };
+    let end1 = Atm::next_state(&start, &Action::PressKey(Key::Two));
+    let expected1 = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: vec![Key::One, Key::Two],
+    };
+
+    assert_eq!(end1, expected1);
 }
 
 #[test]
 fn sm_3_enter_wrong_pin() {
-    todo!()
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: vec![Key::Three, Key::Three, Key::Three, Key::Three],
+    };
+    let end = Atm::next_state(&start, &Action::PressKey(Key::Enter));
+    let expected = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Waiting,
+        keystroke_register: Vec::new(),
+    };
+
+    assert_eq!(end, expected);
 }
 
 #[test]
 fn sm_3_enter_correct_pin() {
-    todo!()
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticating(1234),
+        keystroke_register: vec![Key::One, Key::Two, Key::Three, Key::Four],
+    };
+    let end = Atm::next_state(&start, &Action::PressKey(Key::Enter));
+    let expected = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticated,
+        keystroke_register: Vec::new(),
+    };
+
+    assert_eq!(end, expected);
 }
 
 #[test]
 fn sm_3_enter_single_digit_of_withdraw_amount() {
-    todo!()
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticated,
+        keystroke_register: Vec::new(),
+    };
+    let end = Atm::next_state(&start, &Action::PressKey(Key::One));
+    let expected = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticated,
+        keystroke_register: vec![Key::One],
+    };
+
+    assert_eq!(end, expected);
+
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticated,
+        keystroke_register: vec![Key::One],
+    };
+    let end1 = Atm::next_state(&start, &Action::PressKey(Key::Four));
+    let expected1 = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticated,
+        keystroke_register: vec![Key::One, Key::Four],
+    };
+
+    assert_eq!(end1, expected1);
 }
 
 #[test]
 fn sm_3_try_to_withdraw_too_much() {
-    todo!()
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticated,
+        keystroke_register: vec![Key::One, Key::Four],
+    };
+    let end = Atm::next_state(&start, &Action::PressKey(Key::Enter));
+    let expected = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Waiting,
+        keystroke_register: Vec::new(),
+    };
+
+    assert_eq!(end, expected);
 }
 
 #[test]
 fn sm_3_withdraw_acceptable_amount() {
-    todo!()
+    let start = Atm {
+        cash_inside: 10,
+        expected_pin_hash: Auth::Authenticated,
+        keystroke_register: vec![Key::One],
+    };
+    let end = Atm::next_state(&start, &Action::PressKey(Key::Enter));
+    let expected = Atm {
+        cash_inside: 9,
+        expected_pin_hash: Auth::Waiting,
+        keystroke_register: Vec::new(),
+    };
+
+    assert_eq!(end, expected);
 }


### PR DESCRIPTION
Added the Clone trait because it made the exercise more convenient (less hustle with handling the shared reference of `starting_state` parameter in `fn next_state()`