### PR TITLE
Update p1_switches.rs

### DIFF
--- a/src/c1_state_machine/p1_switches.rs
+++ b/src/c1_state_machine/p1_switches.rs
@@ -15,7 +15,7 @@ impl StateMachine for LightSwitch {
     type Transition = ();
 
     fn next_state(starting_state: &bool, _: &()) -> bool {
-        !starting_state
+        !*starting_state
     }
 }
 


### PR DESCRIPTION
mismatched types [E0308] expected `bool`, found `&bool`