### PR TITLE
Dedicated `HashValue` type to make it less ambiguous working with hashes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@ mod c2_blockchain;
 mod c3_consensus;
 mod c4_framework;
 
+//TODO This is just me scribbling a quick little idea to disambiguate the hash type throughout this project.
+/// A Simple 64-bit hash value that will be used whenever a cryptographic hash is needed.
+pub struct HashValue(u64);
+
 // Simple helper to do some hashing.
 fn hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();


### PR DESCRIPTION
This PR adds a type called `HashValue` which is a thin wrapper around a `u64`. This should free the learner's mind from having to remember that hashes are just `u64`s and from remembering which `u64`s are being treated like hashes and which are numbers that you might want to perform arithmetic on.