### PR TITLE
genesis ext_root expected to be hash of empty vec

### DIFF
--- a/src/c2_blockchain/p4_batched_extrinsics.rs
+++ b/src/c2_blockchain/p4_batched_extrinsics.rs
@@ -110,7 +110,7 @@ fn bc_4_genesis_header() {
     let g = Header::genesis();
     assert_eq!(g.height, 0);
     assert_eq!(g.parent, 0);
-    assert_eq!(g.extrinsics_root, 0);
+    assert_eq!(g.extrinsics_root, hash(&Vec::<u64>::new()));
     assert_eq!(g.state, 0);
 }
 

--- a/src/c2_blockchain/p6_rich_state.rs
+++ b/src/c2_blockchain/p6_rich_state.rs
@@ -127,7 +127,7 @@ fn bc_6_genesis_header() {
     let g = Header::genesis(hash(&state));
     assert_eq!(g.height, 0);
     assert_eq!(g.parent, 0);
-    assert_eq!(g.extrinsics_root, 0);
+    assert_eq!(g.extrinsics_root, hash(&Vec::<u64>::new()));
     assert_eq!(g.state_root, hash(&state));
 }
 


### PR DESCRIPTION
This is more of a conceptual thing than a technical one. Implementing `verify_sub_chain` in `p4_batched_extrinsic`, I noticed the following:

```rust 
let valid_header = self.header.extrinsics_root == hash(&self.body);
```

resulted in being incorrect, and I had to correct it to:

```rust 
let valid_header = self.header.height == 0 || self.header.extrinsics_root == hash(&self.body);
```

because in the genesis header, the `extrinsics_root` is expected to be zero.

I didn't like this, so I propose to expect it to be the hash of an empty vector so that the same `verify_sub_chain` code can apply to every block!

If you disagree and believe that hashing an empty vector is more cumbersome than using zero as the first `extrinsics_root`, feel free to close the PR!
