### PR TITLE
PowOrPoaDigest as digest in AlternatingPowPoa impl

### DIFF
--- a/src/c3_consensus/p5_interleave.rs
+++ b/src/c3_consensus/p5_interleave.rs
@@ -4,7 +4,7 @@
 //! this approach as a way to transition away from PoW.
 
 /// A Consensus engine that alternates back and forth between PoW and PoA sealed blocks.
-/// 
+///
 /// Odd blocks are PoW
 /// Even blocks are PoA
 struct AlternatingPowPoa;
@@ -41,13 +41,13 @@ impl From<ConsensusAuthority> for PowOrPoaDigest {
 impl TryFrom<PowOrPoaDigest> for ConsensusAuthority {
     type Error = ();
 
-    fn try_from(_: PowOrPoaDigest) -> Result<Self, Self::Error>  {
+    fn try_from(_: PowOrPoaDigest) -> Result<Self, Self::Error> {
         todo!("Exercise 4")
     }
 }
 
 impl Consensus for AlternatingPowPoa {
-    type Digest = ConsensusAuthority;
+    type Digest = PowOrPoaDigest;
 
     fn validate(&self, parent_digest: &Self::Digest, header: &Header<Self::Digest>) -> bool {
         todo!("Exercise 5")


### PR DESCRIPTION
`AlternatingPowPoa`, probably, had the wrong `Digest` in `Consensus` trait implementation

plus some rustfmt changes 